### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
   settings:
     staticcheck:
@@ -9,26 +11,19 @@ linters:
         - fmt
         - github.com/onsi/ginkgo/v2
         - github.com/onsi/gomega
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/evaluator/eval.go
+++ b/pkg/evaluator/eval.go
@@ -132,7 +132,9 @@ func getProgramForRule(rule string) (cel.Program, error) {
 	}
 	env, err := cel.NewEnv(
 		cel.VariableDecls(
-			decls.NewVariable(defaultCELVar, types.DynType)))
+			decls.NewVariable(defaultCELVar, types.DynType),
+		),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/crd.go
+++ b/test/e2e/framework/crd.go
@@ -28,25 +28,26 @@ import (
 )
 
 func (f *Framework) EnsureCRD() GomegaAsyncAssertion {
-	return Eventually(func() error {
-		if err := f.kc.List(f.ctx, &api.RecommendationList{}); err != nil {
-			return fmt.Errorf("CRD Recommendation is not ready, Reason: %v", err)
-		}
+	return Eventually(
+		func() error {
+			if err := f.kc.List(f.ctx, &api.RecommendationList{}); err != nil {
+				return fmt.Errorf("CRD Recommendation is not ready, Reason: %v", err)
+			}
 
-		if err := f.kc.List(f.ctx, &api.MaintenanceWindowList{}); err != nil {
-			return fmt.Errorf("CRD MaintainenceWindow is not ready, Reason: %v", err)
-		}
+			if err := f.kc.List(f.ctx, &api.MaintenanceWindowList{}); err != nil {
+				return fmt.Errorf("CRD MaintainenceWindow is not ready, Reason: %v", err)
+			}
 
-		if err := f.kc.List(f.ctx, &api.ClusterMaintenanceWindowList{}); err != nil {
-			return fmt.Errorf("CRD ClusterMaintainenceWindow is not ready, Reason: %v", err)
-		}
+			if err := f.kc.List(f.ctx, &api.ClusterMaintenanceWindowList{}); err != nil {
+				return fmt.Errorf("CRD ClusterMaintainenceWindow is not ready, Reason: %v", err)
+			}
 
-		if err := f.kc.List(f.ctx, &api.ApprovalPolicyList{}); err != nil {
-			return fmt.Errorf("CRD ApprovalPolicy is not ready, Reason: %v", err)
-		}
+			if err := f.kc.List(f.ctx, &api.ApprovalPolicyList{}); err != nil {
+				return fmt.Errorf("CRD ApprovalPolicy is not ready, Reason: %v", err)
+			}
 
-		return nil
-	},
+			return nil
+		},
 		time.Minute*2,
 		time.Second*10,
 	)


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
